### PR TITLE
Improve memory store. Hashmap to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,19 +136,19 @@ python benchmarks.py
 
 | Depth | Hash | Store | Throughput (Kelem/s) |
 |---|---|---|---|
-| 32 | keccak256 | rocksdb | 19.562 |
-| 32 | keccak256 | sqlite | 30.350 |
-| 32 | keccak256 | sled | 64.631 |
-| 32 | keccak256 | memory | 131.510 |
+| 32 | keccak256 | rocksdb | 21.945 |
+| 32 | keccak256 | sqlite | 30.170 |
+| 32 | keccak256 | sled | 64.759 |
+| 32 | keccak256 | memory | 143.700 |
 
 ### `proof` time
 
 | Depth | Hash | Store | Time |
 |---|---|---|---|
-| 32 | keccak256 | memory | 490.050 ns |
-| 32 | keccak256 | sled | 6.422 µs |
-| 32 | keccak256 | sqlite | 11.304 µs |
-| 32 | keccak256 | rocksdb | 42.014 µs |
+| 32 | keccak256 | memory | 188.250 ns |
+| 32 | keccak256 | sled | 6.436 µs |
+| 32 | keccak256 | sqlite | 11.366 µs |
+| 32 | keccak256 | rocksdb | 30.235 µs |
 
 ## License
 

--- a/src/stores/memory_store.rs
+++ b/src/stores/memory_store.rs
@@ -1,15 +1,15 @@
 // Copyright 2025 Bilinear Labs - MIT License
 
-//! Simple in-memory store implementation.
+//! In-memory store implementation.
 
 use crate::{MerkleError, Node, Store};
-use std::collections::HashMap;
+use std::cmp::Ordering;
 
-/// Simple in-memory store implementation using a `HashMap`.
 #[derive(Default)]
 pub struct MemoryStore {
-    store: HashMap<(u32, u64), Node>,
-    num_leaves: u64,
+    /// `levels[l][idx]` is the node at level `l`, index `idx`. `levels[0]` holds
+    /// the leaves, so `levels[0].len()` is the number of leaves.
+    levels: Vec<Vec<Node>>,
 }
 
 impl MemoryStore {
@@ -27,26 +27,101 @@ impl Store for MemoryStore {
             });
         }
 
-        // The memory store doesnt really allow batch reads, so just get all the
-        // indexes/levels one by one.
-        let result = levels
+        Ok(levels
             .iter()
             .zip(indices)
-            .map(|(&lvl, &idx)| self.store.get(&(lvl, idx)).cloned())
-            .collect();
-
-        Ok(result)
+            .map(|(&level, &index)| {
+                self.levels
+                    .get(level as usize)
+                    .and_then(|nodes| nodes.get(index as usize))
+                    .copied()
+            })
+            .collect())
     }
 
     fn put(&mut self, items: &[(u32, u64, Node)]) -> Result<(), MerkleError> {
-        for (level, index, hash) in items {
-            self.store.insert((*level, *index), *hash);
+        let Some(max_level) = items.iter().map(|&(level, _, _)| level).max() else {
+            return Ok(());
+        };
+        let max_level = max_level as usize;
+        if self.levels.len() <= max_level {
+            self.levels.resize_with(max_level + 1, Vec::new);
         }
-        let counter = items.iter().filter(|(level, _, _)| *level == 0).count();
-        self.num_leaves += counter as u64;
+
+        for &(level, index, node) in items {
+            let nodes = &mut self.levels[level as usize];
+            let index = index as usize;
+            match index.cmp(&nodes.len()) {
+                Ordering::Equal => nodes.push(node),
+                Ordering::Less => nodes[index] = node,
+                Ordering::Greater => {
+                    return Err(MerkleError::StoreError(format!(
+                        "non-contiguous put at level {level}: index {index} is past the stored prefix of {}",
+                        nodes.len()
+                    )));
+                }
+            }
+        }
+
         Ok(())
     }
+
     fn get_num_leaves(&self) -> u64 {
-        self.num_leaves
+        self.levels.first().map_or(0, |leaves| leaves.len() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(byte: u8) -> Node {
+        Node::from([byte; Node::LEN])
+    }
+
+    #[test]
+    fn put_get_roundtrip() {
+        let mut store = MemoryStore::new();
+
+        // Simple tree with 4 leaves at the bottom, 2 at level 1, and 1 at level 2.
+        store
+            .put(&[
+                // Merkle tree (4 leaves):
+                //
+                //                  0xff                  <- level 2 (root), index 0
+                //                 /    \
+                //              0xaa    0xbb              <- level 1, indices 0..1
+                //              /  \    /  \
+                //           0x0a 0x0b 0x0c 0x0d          <- level 0 (leaves), indices 0..3
+                //   index:   0    1    2    3
+                (0, 0, node(0x0a)),
+                (0, 1, node(0x0b)),
+                (0, 2, node(0x0c)),
+                (0, 3, node(0x0d)),
+                (1, 0, node(0xaa)),
+                (1, 1, node(0xbb)),
+                (2, 0, node(0xff)),
+            ])
+            .unwrap();
+
+        assert_eq!(store.get_num_leaves(), 4);
+        assert_eq!(
+            {
+                let (l, i): (Vec<u32>, Vec<u64>) =
+                    [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (2, 0)]
+                        .into_iter()
+                        .unzip();
+                store.get(&l, &i).unwrap()
+            },
+            vec![
+                Some(node(0x0a)),
+                Some(node(0x0b)),
+                Some(node(0x0c)),
+                Some(node(0x0d)),
+                Some(node(0xaa)),
+                Some(node(0xbb)),
+                Some(node(0xff)),
+            ],
+        );
     }
 }


### PR DESCRIPTION
* This PR massively improves the performance of the get proof call for the memory store.
* Before, leaves were stored in a hashmap. (level, idx) -> leaf.
* Now, leaves are stored in a Vec of Vec. `levels[l][idx]` is the node at level `l`, index `idx`. `levels[0]` holds the leaves, so `levels[0].len()` is the number of leaves.
* This avoids the hashing required by the hashmap, massively increasing performance, specially for the get proof.