### PR TITLE
Implement custom storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/.DS_Store
 **/target
-# This is a library crate
+**/.vscode
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ path = "src/lib.rs"
 [features]
 all = ["all_stores"]
 default = ["memory_store"]
-all_stores = ["memory_store", "sled_store", "sqlite_store", "rocksdb_store"]
+all_stores = ["memory_store", "sled_store", "sqlite_store", "rocksdb_store", "file_store"]
 memory_store = []
 sled_store = ["dep:sled"]
 sqlite_store = ["rusqlite/bundled"]
 rocksdb_store = ["dep:rocksdb"]
+file_store = []
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/README.md
+++ b/README.md
@@ -94,12 +94,31 @@ fn main() {
 }
 ```
 
+**Depth: 32 | Hashing: Keccak | Store: file**
+
+```toml
+rs-merkle-tree = { version = "0.1.0", features = ["file_store"] }
+```
+
+```rust
+use rs_merkle_tree::hasher::Keccak256Hasher;
+use rs_merkle_tree::stores::FileStore;
+use rs_merkle_tree::tree::MerkleTree;
+
+fn main() {
+    // Stores one flat file per level inside the given directory.
+    let mut tree: MerkleTree<Keccak256Hasher, FileStore, 32> =
+        MerkleTree::new(Keccak256Hasher, FileStore::new("filestore.db"));
+}
+```
+
 ## Stores
 
 The following stores are supported:
 * [rusqlite](https://github.com/rusqlite/rusqlite)
 * [rocksdb](https://github.com/rust-rocksdb/rust-rocksdb)
 * [sled](https://github.com/spacejam/sled)
+* `file`: a flat store (no database engine) that keeps one file per level in a directory.
 
 ## Hash functions
 
@@ -131,24 +150,27 @@ python benchmarks.py
 | sled | 32 | 1000000 | 290.00 |
 | sqlite | 32 | 1000000 | 159.18 |
 | rocksdb | 32 | 1000000 | 183.27 |
+| file | 32 | 1000000 | 61.04 |
 
 ### `add_leaves` throughput
 
 | Depth | Hash | Store | Throughput (Kelem/s) |
 |---|---|---|---|
-| 32 | keccak256 | rocksdb | 21.945 |
-| 32 | keccak256 | sqlite | 30.170 |
-| 32 | keccak256 | sled | 64.759 |
-| 32 | keccak256 | memory | 143.700 |
+| 32 | keccak256 | rocksdb | 18.047 |
+| 32 | keccak256 | sqlite | 31.300 |
+| 32 | keccak256 | sled | 62.861 |
+| 32 | keccak256 | file | 135.790 |
+| 32 | keccak256 | memory | 142.940 |
 
 ### `proof` time
 
 | Depth | Hash | Store | Time |
 |---|---|---|---|
-| 32 | keccak256 | memory | 188.250 ns |
-| 32 | keccak256 | sled | 6.436 µs |
-| 32 | keccak256 | sqlite | 11.366 µs |
-| 32 | keccak256 | rocksdb | 30.235 µs |
+| 32 | keccak256 | memory | 188.280 ns |
+| 32 | keccak256 | file | 5.150 µs |
+| 32 | keccak256 | sled | 6.439 µs |
+| 32 | keccak256 | sqlite | 11.341 µs |
+| 32 | keccak256 | rocksdb | 41.998 µs |
 
 ## License
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,7 +1,7 @@
 use criterion::black_box;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::random;
-use rs_merkle_tree::stores::{MemoryStore, RocksDbStore, SledStore, SqliteStore};
+use rs_merkle_tree::stores::{FileStore, MemoryStore, RocksDbStore, SledStore, SqliteStore};
 use rs_merkle_tree::{hasher::Keccak256Hasher, node::Node, tree::MerkleTree};
 
 // Constants for the benchmarks
@@ -22,6 +22,7 @@ fn bench_insertions(c: &mut Criterion) {
     let _ = std::fs::remove_file("sqlite.db");
     let _ = std::fs::remove_dir_all("sled.db");
     let _ = std::fs::remove_file("rocksdb.db");
+    let _ = std::fs::remove_dir_all("file.db");
 
     let mut memory_tree: MerkleTree<Keccak256Hasher, MemoryStore, 32> =
         MerkleTree::new(Keccak256Hasher, MemoryStore::default());
@@ -31,6 +32,8 @@ fn bench_insertions(c: &mut Criterion) {
         MerkleTree::new(Keccak256Hasher, SledStore::new("sled.db", false));
     let mut rocksdb_tree: MerkleTree<Keccak256Hasher, RocksDbStore, 32> =
         MerkleTree::new(Keccak256Hasher, RocksDbStore::new("rocksdb.db"));
+    let mut file_tree: MerkleTree<Keccak256Hasher, FileStore, 32> =
+        MerkleTree::new(Keccak256Hasher, FileStore::new("file.db"));
 
     // Depth 32 benchmarks Keccak256
     group.throughput(Throughput::Elements((NUM_BATCHES * BATCH_SIZE) as u64));
@@ -80,6 +83,17 @@ fn bench_insertions(c: &mut Criterion) {
             });
         },
     );
+    group.throughput(Throughput::Elements((NUM_BATCHES * BATCH_SIZE) as u64));
+    group.bench_function(BenchmarkId::new("file_store", "depth32_keccak256"), |b| {
+        b.iter(|| {
+            for _ in 0..NUM_BATCHES {
+                let leaves: Vec<Node> = (0..BATCH_SIZE)
+                    .map(|_| black_box(Node::random()))
+                    .collect::<Vec<Node>>();
+                file_tree.add_leaves(&leaves).unwrap();
+            }
+        });
+    });
 
     // Depth 32 benchmarks Poseidon
     // TODO: Benchmarks not working due to inputs being bigger than the prime
@@ -125,6 +139,7 @@ fn bench_insertions(c: &mut Criterion) {
     let _ = std::fs::remove_file("sqlite.db");
     let _ = std::fs::remove_dir_all("sled.db");
     let _ = std::fs::remove_file("rocksdb.db");
+    let _ = std::fs::remove_dir_all("file.db");
 
     group.finish();
 }
@@ -140,6 +155,7 @@ fn bench_get_proof(c: &mut Criterion) {
     let _ = std::fs::remove_file("sqlite.db");
     let _ = std::fs::remove_dir_all("sled.db");
     let _ = std::fs::remove_file("rocksdb.db");
+    let _ = std::fs::remove_dir_all("file.db");
 
     let mut memory_tree: MerkleTree<Keccak256Hasher, MemoryStore, 32> =
         MerkleTree::new(Keccak256Hasher, MemoryStore::default());
@@ -149,6 +165,8 @@ fn bench_get_proof(c: &mut Criterion) {
         MerkleTree::new(Keccak256Hasher, SledStore::new("sled.db", false));
     let mut rocksdb_tree: MerkleTree<Keccak256Hasher, RocksDbStore, 32> =
         MerkleTree::new(Keccak256Hasher, RocksDbStore::new("rocksdb.db"));
+    let mut file_tree: MerkleTree<Keccak256Hasher, FileStore, 32> =
+        MerkleTree::new(Keccak256Hasher, FileStore::new("file.db"));
 
     for _ in 0..NUM_BATCHES {
         let leaves: Vec<Node> = (0..BATCH_SIZE)
@@ -158,6 +176,7 @@ fn bench_get_proof(c: &mut Criterion) {
         sqlite_tree.add_leaves(&leaves).unwrap();
         sled_tree.add_leaves(&leaves).unwrap();
         rocksdb_tree.add_leaves(&leaves).unwrap();
+        file_tree.add_leaves(&leaves).unwrap();
     }
 
     group.bench_function(BenchmarkId::new("memory_store", "depth32_keccak256"), |b| {
@@ -188,11 +207,18 @@ fn bench_get_proof(c: &mut Criterion) {
             });
         },
     );
+    group.bench_function(BenchmarkId::new("file_store", "depth32_keccak256"), |b| {
+        b.iter(|| {
+            let i = random::<u64>() % (BATCH_SIZE * NUM_BATCHES);
+            file_tree.proof(i).unwrap();
+        });
+    });
 
     // Cleanup
     let _ = std::fs::remove_file("sqlite.db");
     let _ = std::fs::remove_dir_all("sled.db");
     let _ = std::fs::remove_file("rocksdb.db");
+    let _ = std::fs::remove_dir_all("file.db");
 
     group.finish();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,10 @@ pub mod stores {
     mod rocksdb_store;
     #[cfg(feature = "rocksdb_store")]
     pub use rocksdb_store::RocksDbStore;
+    #[cfg(feature = "file_store")]
+    mod file_store;
+    #[cfg(feature = "file_store")]
+    pub use file_store::FileStore;
 }
 
 // Re-export the store module for easier access

--- a/src/stores/file_store.rs
+++ b/src/stores/file_store.rs
@@ -1,0 +1,317 @@
+// Copyright 2025 Bilinear Labs - MIT License
+
+//! Flat file store implementation.
+//!
+//! Stores the tree as one flat file per level inside a directory. Since the Merkle tree
+//! is append only, all files at each level can be append only. Inserts are batched to only
+//! trigger a syscall per level.
+//!
+//! TODO: There is no WAL nor recovery strategy if the file goes corrupt.
+
+use crate::{MerkleError, Node, Store};
+use std::fs::{create_dir_all, File, OpenOptions};
+use std::os::unix::fs::FileExt;
+use std::path::PathBuf;
+
+/// Flat file store: one file per level.
+pub struct FileStore {
+    /// Directory where the store is placed
+    dir: PathBuf,
+    /// Open file handle per level.
+    files: Vec<File>,
+    /// Number of nodes stored at each level, i.e. `file_len / Node::LEN`.
+    /// `counts[0]` is the number of leaves, bottom level.
+    counts: Vec<u64>,
+}
+
+fn io_err<E: std::fmt::Display>(err: E) -> MerkleError {
+    MerkleError::StoreError(err.to_string())
+}
+
+fn level_file_name(level: usize) -> String {
+    format!("level_{:03}", level)
+}
+
+impl FileStore {
+    /// Opens (creating if needed) a file store rooted at `dir`.
+    pub fn new(dir: &str) -> Self {
+        let dir = PathBuf::from(dir);
+        create_dir_all(&dir).expect("failed to create file store directory");
+
+        let node_len = Node::LEN as u64;
+        let mut files = Vec::new();
+        let mut counts = Vec::new();
+
+        // Levels are written as a contiguous path 0..=DEPTH, so existing level
+        // files form a contiguous run. Probe level_000, level_001, etc
+        loop {
+            let path = dir.join(level_file_name(files.len()));
+            if !path.exists() {
+                break;
+            }
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .expect("failed to open level file");
+            let len = file
+                .metadata()
+                .expect("failed to read level file metadata")
+                .len();
+            files.push(file);
+
+            counts.push(len / node_len);
+        }
+
+        Self { dir, files, counts }
+    }
+
+    /// Ensures a file (and count slot) exists for every level up to `level`.
+    fn ensure_level(&mut self, level: usize) -> Result<(), MerkleError> {
+        while self.files.len() <= level {
+            let path = self.dir.join(level_file_name(self.files.len()));
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+                .map_err(io_err)?;
+            let count = file.metadata().map_err(io_err)?.len() / Node::LEN as u64;
+            self.counts.push(count);
+            self.files.push(file);
+        }
+        Ok(())
+    }
+}
+
+impl Store for FileStore {
+    fn get(&self, levels: &[u32], indices: &[u64]) -> Result<Vec<Option<Node>>, MerkleError> {
+        if levels.len() != indices.len() {
+            return Err(MerkleError::LengthMismatch {
+                levels: levels.len(),
+                indices: indices.len(),
+            });
+        }
+
+        levels
+            .iter()
+            .zip(indices)
+            .map(|(&lvl, &idx)| {
+                let level = lvl as usize;
+                // A node is present if its index is within the stored prefix.
+                // This also makes reads beyond the tree (allowed by `proof`)
+                // return `None`, which the tree maps to `zeros[level]`.
+                if level >= self.counts.len() || idx >= self.counts[level] {
+                    return Ok(None);
+                }
+                let mut bytes = [0u8; Node::LEN];
+                self.files[level]
+                    .read_exact_at(&mut bytes, idx * Node::LEN as u64)
+                    .map_err(io_err)?;
+                Ok(Some(Node::from(bytes)))
+            })
+            .collect()
+    }
+
+    fn put(&mut self, items: &[(u32, u64, Node)]) -> Result<(), MerkleError> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        // Writes are batched per level, so here we rearrange items to have a single sequence of bytes
+        // to append to each level. Check are also performed to ensure its trully append only without
+        // out of sequence stores.
+
+        // A batch can rewrite the same right-spine node once per leaf, and the
+        // indices it touches at each level form one contiguous run. Buffer one
+        // run per level, then flush each with a single positional write.
+        let max_level = items.iter().map(|&(level, _, _)| level).max().unwrap() as usize;
+        self.ensure_level(max_level)?;
+
+        // Per level: the index the run starts at, and its nodes. Note elements can be empty
+        // meaning there is nothing to write at that level.
+        let mut runs: Vec<(u64, Vec<Node>)> = vec![(0, Vec::new()); max_level + 1];
+
+        for &(level, index, node) in items {
+            let level = level as usize;
+            let (start, run) = &mut runs[level];
+
+            // The level's first entry fixes where its run starts. The batch may
+            // append at the end of the stored prefix or rewrite inside it, but
+            // starting past it would leave a hole that reads back as a node.
+            if run.is_empty() {
+                if index > self.counts[level] {
+                    return Err(io_err(format!(
+                        "put batch at level {level} starts at index {index}, past the stored prefix of {}",
+                        self.counts[level]
+                    )));
+                }
+                *start = index;
+            }
+
+            // Position within the run. Only two placements keep it contiguous:
+            // overwriting a node already buffered (last write wins), or
+            // extending it by one. Anything else would leave a hole, and
+            // growing only by `push` keeps the run bounded by the batch size,
+            // so an absurd index errors instead of allocating its span.
+            match index
+                .checked_sub(*start)
+                .and_then(|rel| usize::try_from(rel).ok())
+            {
+                Some(rel) if rel < run.len() => run[rel] = node,
+                Some(rel) if rel == run.len() => run.push(node),
+                _ => {
+                    return Err(io_err(format!(
+                        "non-contiguous put batch at level {level}: index {index} is not contiguous with [{}, {})",
+                        *start,
+                        *start + run.len() as u64
+                    )));
+                }
+            }
+        }
+
+        for (level, (start, run)) in runs.into_iter().enumerate() {
+            if run.is_empty() {
+                continue;
+            }
+            let mut bytes = Vec::with_capacity(run.len() * Node::LEN);
+            for node in &run {
+                bytes.extend_from_slice(node.as_ref());
+            }
+            self.files[level]
+                .write_all_at(&bytes, start * Node::LEN as u64)
+                .map_err(io_err)?;
+            self.counts[level] = self.counts[level].max(start + run.len() as u64);
+        }
+
+        Ok(())
+    }
+
+    fn get_num_leaves(&self) -> u64 {
+        self.counts.first().copied().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(byte: u8) -> Node {
+        Node::from([byte; Node::LEN])
+    }
+
+    fn temp_dir(name: &str) -> String {
+        let dir = std::env::temp_dir().join(format!(
+            "rs_merkle_file_store_{name}_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir.to_str().expect("utf-8 temp path").to_owned()
+    }
+
+    #[test]
+    fn put_get_roundtrip_with_duplicates() {
+        let dir = temp_dir("roundtrip");
+        let mut store = FileStore::new(&dir);
+
+        // Duplicated (level, index) entries within a batch: last write wins,
+        // mirroring how the tree rewrites the right spine within a batch.
+        store
+            .put(&[
+                (0, 0, node(0x0a)),
+                (1, 0, node(0xff)),
+                (0, 1, node(0x0b)),
+                (1, 0, node(0x1a)),
+            ])
+            .unwrap();
+
+        assert_eq!(store.get_num_leaves(), 2);
+        assert_eq!(
+            store.get(&[0, 0, 1], &[0, 1, 0]).unwrap(),
+            vec![Some(node(0x0a)), Some(node(0x0b)), Some(node(0x1a))]
+        );
+
+        // A later batch overwriting the spine tail (lo < count) keeps siblings.
+        store
+            .put(&[(0, 2, node(0x0c)), (1, 1, node(0x1b))])
+            .unwrap();
+        assert_eq!(
+            store.get(&[0, 1, 1], &[2, 0, 1]).unwrap(),
+            vec![Some(node(0x0c)), Some(node(0x1a)), Some(node(0x1b))]
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn out_of_range_reads_are_none() {
+        let dir = temp_dir("out_of_range");
+        let mut store = FileStore::new(&dir);
+        store
+            .put(&[(0, 0, node(0x0a)), (1, 0, node(0x1a))])
+            .unwrap();
+
+        // Beyond the stored prefix of an existing level and beyond all levels.
+        assert_eq!(
+            store.get(&[0, 1, 7], &[1, 9, 0]).unwrap(),
+            vec![None, None, None]
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn non_contiguous_batches_are_rejected() {
+        let dir = temp_dir("non_contiguous");
+        let mut store = FileStore::new(&dir);
+        store.put(&[(0, 0, node(0x0a))]).unwrap();
+
+        // A hole inside the batch, even masked by a duplicate.
+        assert!(store
+            .put(&[(0, 1, node(0x0b)), (0, 3, node(0x0c))])
+            .is_err());
+        assert!(store
+            .put(&[(0, 1, node(0x0b)), (0, 1, node(0x0b)), (0, 3, node(0x0c))])
+            .is_err());
+        // A batch starting past the stored prefix.
+        assert!(store.put(&[(0, 5, node(0x0d))]).is_err());
+        // An absurd index range must error, not allocate by range size.
+        assert!(store
+            .put(&[(0, 1, node(0x0e)), (0, u64::MAX, node(0x0f))])
+            .is_err());
+
+        // The store stays usable and unchanged after rejections.
+        assert_eq!(store.get_num_leaves(), 1);
+        store.put(&[(0, 1, node(0x0b))]).unwrap();
+        assert_eq!(store.get_num_leaves(), 2);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn reopen_keeps_everything() {
+        let dir = temp_dir("reopen");
+        {
+            let mut store = FileStore::new(&dir);
+            store
+                .put(&[(0, 0, node(0x0a)), (0, 1, node(0x0b)), (1, 0, node(0x1a))])
+                .unwrap();
+        }
+
+        let mut store = FileStore::new(&dir);
+        assert_eq!(store.get_num_leaves(), 2);
+        assert_eq!(store.get(&[1], &[0]).unwrap(), vec![Some(node(0x1a))]);
+
+        store
+            .put(&[(0, 2, node(0x0c)), (1, 1, node(0x1b))])
+            .unwrap();
+        assert_eq!(store.get_num_leaves(), 3);
+        assert_eq!(
+            store.get(&[0, 1], &[2, 1]).unwrap(),
+            vec![Some(node(0x0c)), Some(node(0x1b))]
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/tests/store.rs
+++ b/tests/store.rs
@@ -1,10 +1,12 @@
 // Copyright 2025 Bilinear Labs - MIT License
 
 use rs_merkle_tree::{node::Node, to_node, Store};
-#[cfg(feature = "rocksdb_store")]
+#[cfg(any(feature = "rocksdb_store", feature = "file_store"))]
 use std::fs;
 use temp_file::TempFile;
 
+#[cfg(feature = "file_store")]
+use rs_merkle_tree::stores::FileStore;
 #[cfg(feature = "memory_store")]
 use rs_merkle_tree::stores::MemoryStore;
 #[cfg(feature = "rocksdb_store")]
@@ -13,6 +15,22 @@ use rs_merkle_tree::stores::RocksDbStore;
 use rs_merkle_tree::stores::SledStore;
 #[cfg(feature = "sqlite_store")]
 use rs_merkle_tree::stores::SqliteStore;
+
+// Builds a unique temporary directory path for the file store and removes the
+// placeholder file so `FileStore::new` can create a directory there.
+#[cfg(feature = "file_store")]
+fn temp_file_store_path() -> String {
+    let temp = TempFile::with_suffix("_filestore").unwrap();
+    let path = temp
+        .path()
+        .as_os_str()
+        .to_str()
+        .expect("Failed to build path for FileStore")
+        .to_owned();
+    temp.cleanup()
+        .expect("Failed to cleanup FileStore placeholder");
+    path
+}
 
 #[test]
 fn test_stores_single() {
@@ -36,11 +54,16 @@ fn test_stores_single() {
         .expect("Failed to cleanup RocksDB");
     println!("RocksDB path: {}", path_rocksdb);
 
+    #[cfg(feature = "file_store")]
+    let path_file = temp_file_store_path();
+
     // Test all implemented stores
     let mut stores: Vec<Box<dyn Store>> = Vec::new();
 
     #[cfg(feature = "memory_store")]
     stores.push(Box::new(MemoryStore::default()));
+    #[cfg(feature = "file_store")]
+    stores.push(Box::new(FileStore::new(&path_file)));
     #[cfg(feature = "sled_store")]
     stores.push(Box::new(SledStore::new("/tmp/sled1.db", true)));
     #[cfg(feature = "sqlite_store")]
@@ -84,6 +107,10 @@ fn test_stores_single() {
     // Now delete the RocksDB directory.
     #[cfg(feature = "rocksdb_store")]
     fs::remove_dir_all(path_rocksdb).expect("Failed to delete RocksDB file");
+
+    // Delete the FileStore directory.
+    #[cfg(feature = "file_store")]
+    fs::remove_dir_all(path_file).expect("Failed to delete FileStore directory");
 }
 
 #[test]
@@ -108,11 +135,16 @@ fn test_stores_multiple() {
         .expect("Failed to cleanup RocksDB");
     println!("RocksDB path: {}", path_rocksdb);
 
+    #[cfg(feature = "file_store")]
+    let path_file = temp_file_store_path();
+
     // Test all implemented stores
     let mut stores: Vec<Box<dyn Store>> = Vec::new();
 
     #[cfg(feature = "memory_store")]
     stores.push(Box::new(MemoryStore::default()));
+    #[cfg(feature = "file_store")]
+    stores.push(Box::new(FileStore::new(&path_file)));
     #[cfg(feature = "sled_store")]
     stores.push(Box::new(SledStore::new("/tmp/sled2.db", true)));
     #[cfg(feature = "sqlite_store")]
@@ -257,4 +289,8 @@ fn test_stores_multiple() {
     // Now delete the RocksDB directory.
     #[cfg(feature = "rocksdb_store")]
     fs::remove_dir_all(path_rocksdb).expect("Failed to delete RocksDB file");
+
+    // Delete the FileStore directory.
+    #[cfg(feature = "file_store")]
+    fs::remove_dir_all(path_file).expect("Failed to delete FileStore directory");
 }

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -5,6 +5,8 @@ use rs_merkle_tree::{to_node, MerkleTree, Node, Store};
 use std::fs;
 use std::path::Path;
 
+#[cfg(feature = "file_store")]
+use rs_merkle_tree::stores::FileStore;
 #[cfg(feature = "memory_store")]
 use rs_merkle_tree::stores::MemoryStore;
 #[cfg(feature = "rocksdb_store")]
@@ -77,7 +79,8 @@ fn test_merkle_tree_keccak_32_memory() {
 #[cfg(any(
     feature = "sled_store",
     feature = "sqlite_store",
-    feature = "rocksdb_store"
+    feature = "rocksdb_store",
+    feature = "file_store"
 ))]
 #[test]
 #[ignore = "run it on demand, slow and takes some disk space"]
@@ -91,7 +94,7 @@ fn test_disk_space() {
     const BATCH_SIZE: usize = 1_000;
 
     // Clean up any previous runs.
-    ["sled.db", "sqlite.db", "rocksdb.db"]
+    ["sled.db", "sqlite.db", "rocksdb.db", "file.db"]
         .into_iter()
         .for_each(|p| {
             fs::remove_dir_all(p).ok();
@@ -121,6 +124,8 @@ fn test_disk_space() {
     bench_store::<SqliteStore, _>("sqlite.db", || SqliteStore::new("sqlite.db"));
     #[cfg(feature = "rocksdb_store")]
     bench_store::<RocksDbStore, _>("rocksdb.db", || RocksDbStore::new("rocksdb.db"));
+    #[cfg(feature = "file_store")]
+    bench_store::<FileStore, _>("file.db", || FileStore::new("file.db"));
 }
 
 fn print_size(name: &str, file: &str, num_leaves: u64) {


### PR DESCRIPTION
* This PR implements a custom storage, which stores the merkle tree nodes at each level as a simple sequence of bytes in plain files. No key value store, sqlite or any other type of fancy db.
* The fact that the tree is append only, allows for trivial reads and writes:
  * writes: work under the assumption that once an index `i` of a level is written, all future indexes written are `>i`.
  * reads: each level is a file. and within each file the index can be deterministically calculated using the offset. each node is 32 bytes so eg `i=2` has an offset of 32*2 bytes and goes + 32 bytes.
* This massively increases the performance of the tree, see benchmarks. IO is as fast as it gets.
* Once this new storage is tested, most likely I will remove other storage types, since they no longer make sense.