### PR TITLE
Remove redundant hashes in batches

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -9,6 +9,39 @@ const BATCH_SIZE: u64 = 1000;
 const NUM_BATCHES: u64 = 10;
 const SAMPLE_SIZE: u64 = 10;
 
+/// Everything the benchmarked stores write, including the sibling files SQLite
+/// keeps next to the database. A stale WAL would be replayed into the new
+/// database, so it has to go too.
+const STORE_PATHS: [&str; 6] = [
+    "sqlite.db",
+    "sqlite.db-wal",
+    "sqlite.db-shm",
+    "sled.db",
+    "rocksdb.db",
+    "file.db",
+];
+
+/// Deletes every store, whether it is a file or a directory.
+///
+/// Leftover state is not a cosmetic problem: the stores persist their leaf
+/// count, so a surviving database makes the next run resume from it and measure
+/// insertions into an already large tree.
+fn cleanup_stores() {
+    for path in STORE_PATHS {
+        let result = if std::path::Path::new(path).is_dir() {
+            std::fs::remove_dir_all(path)
+        } else {
+            std::fs::remove_file(path)
+        };
+
+        match result {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => panic!("failed to remove {path}: {err}"),
+        }
+    }
+}
+
 fn bench_insertions(c: &mut Criterion) {
     let mut group = c.benchmark_group("inserts");
 
@@ -18,11 +51,7 @@ fn bench_insertions(c: &mut Criterion) {
 
     // TODO: Add benchmarks for different batch sizes
 
-    // TODO: Improve the cleanups.
-    let _ = std::fs::remove_file("sqlite.db");
-    let _ = std::fs::remove_dir_all("sled.db");
-    let _ = std::fs::remove_file("rocksdb.db");
-    let _ = std::fs::remove_dir_all("file.db");
+    cleanup_stores();
 
     let mut memory_tree: MerkleTree<Keccak256Hasher, MemoryStore, 32> =
         MerkleTree::new(Keccak256Hasher, MemoryStore::default());
@@ -136,10 +165,7 @@ fn bench_insertions(c: &mut Criterion) {
      */
 
     // Cleanup
-    let _ = std::fs::remove_file("sqlite.db");
-    let _ = std::fs::remove_dir_all("sled.db");
-    let _ = std::fs::remove_file("rocksdb.db");
-    let _ = std::fs::remove_dir_all("file.db");
+    cleanup_stores();
 
     group.finish();
 }
@@ -151,11 +177,7 @@ fn bench_get_proof(c: &mut Criterion) {
         .sample_size(SAMPLE_SIZE as usize)
         .warm_up_time(std::time::Duration::from_millis(500));
 
-    // TODO: Improve the cleanups.
-    let _ = std::fs::remove_file("sqlite.db");
-    let _ = std::fs::remove_dir_all("sled.db");
-    let _ = std::fs::remove_file("rocksdb.db");
-    let _ = std::fs::remove_dir_all("file.db");
+    cleanup_stores();
 
     let mut memory_tree: MerkleTree<Keccak256Hasher, MemoryStore, 32> =
         MerkleTree::new(Keccak256Hasher, MemoryStore::default());
@@ -215,10 +237,7 @@ fn bench_get_proof(c: &mut Criterion) {
     });
 
     // Cleanup
-    let _ = std::fs::remove_file("sqlite.db");
-    let _ = std::fs::remove_dir_all("sled.db");
-    let _ = std::fs::remove_file("rocksdb.db");
-    let _ = std::fs::remove_dir_all("file.db");
+    cleanup_stores();
 
     group.finish();
 }

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -34,17 +34,20 @@ def _disk_table(rows: List[DiskRow]) -> str:
     )
     return f"{header}\n{body}"
 
-# depth, hash, store, kelem_per_sec
+# depth, hash, store, elem_per_sec
 BenchRow = Tuple[int, str, str, float]
 
 # "inserts/sqlite_store/depth32_keccak256"
 _BENCH_NAME_RE = re.compile(
     r"inserts/(?P<store>[a-zA-Z0-9]+)_store/" r"depth(?P<depth>\d+)_(?P<hash>[a-zA-Z0-9]+)",
 )
-# [10.420 Kelem/s 10.444 Kelem/s 10.468 Kelem/s]"
+# "thrpt:  [10.420 Kelem/s 10.444 Kelem/s 10.468 Kelem/s]"
+# Criterion picks the SI prefix per benchmark, so it must not be hardcoded.
 _THRPT_RE = re.compile(
-    r"thrpt:\s*\[\s*(?P<low>[\d.]+)\s+Kelem/s\s+(?P<mid>[\d.]+)\s+Kelem/s\s+(?P<high>[\d.]+)\s+Kelem/s"  # noqa: W605
+    r"thrpt:\s*\[\s*(?P<low>[\d.]+)\s+[KMG]?elem/s\s+"
+    r"(?P<mid>[\d.]+)\s+(?P<unit>[KMG]?)elem/s"
 )
+_THRPT_FACTOR = {"": 1.0, "K": 1e3, "M": 1e6, "G": 1e9}
 
 
 def _parse_bench(lines: Iterable[str]) -> List[BenchRow]:
@@ -60,22 +63,36 @@ def _parse_bench(lines: Iterable[str]) -> List[BenchRow]:
             current = (depth, hash_alg, store)
             continue
 
-        if current and (thrpt_m := _THRPT_RE.search(line)):
-            kelem_s = float(thrpt_m.group("mid"))
-            depth, hash_alg, store = current
-            rows.append((depth, hash_alg, store, kelem_s))
-            current = None
+        if current is None or "thrpt:" not in line:
+            continue
 
-    rows.sort(key=lambda row: row[3])
+        if thrpt_m := _THRPT_RE.search(line):
+            elem_s = float(thrpt_m.group("mid")) * _THRPT_FACTOR[thrpt_m.group("unit")]
+            depth, hash_alg, store = current
+            rows.append((depth, hash_alg, store, elem_s))
+        # Drop the pending benchmark either way, so an unrecognised line cannot
+        # attach a later measurement to the wrong benchmark.
+        current = None
+
+    rows.sort(key=lambda row: row[3], reverse=True)  # fastest first
     return rows
 
 
 def _bench_table(rows: List[BenchRow]) -> str:
-    header = "| Depth | Hash | Store | Throughput (Kelem/s) |\n" + "|---|---|---|---|"
-    body = "\n".join(
-        f"| {depth} | {hash_alg} | {store} | {kelem:.3f} |"
-        for depth, hash_alg, store, kelem in rows
-    )
+    def _best_unit(elem_s: float) -> tuple[float, str]:
+        """Return value and unit chosen to keep number in readable range."""
+        for factor, unit in ((1e9, "Gelem/s"), (1e6, "Melem/s"), (1e3, "Kelem/s")):
+            if elem_s >= factor:
+                return elem_s / factor, unit
+        return elem_s, "elem/s"
+
+    header = "| Depth | Hash | Store | Throughput |\n" + "|---|---|---|---|"
+    lines: list[str] = []
+    for depth, hash_alg, store, elem_s in rows:
+        val, unit = _best_unit(elem_s)
+        lines.append(f"| {depth} | {hash_alg} | {store} | {val:.3f} {unit} |")
+
+    body = "\n".join(lines)
     return f"{header}\n{body}"
 
 # depth, hash, store, time_ms

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,7 +5,6 @@
 use crate::hasher::{Hasher, Keccak256Hasher};
 use crate::{MerkleError, Node, Store};
 use core::ops::Index;
-use std::collections::HashMap;
 
 #[cfg(feature = "memory_store")]
 use crate::stores::MemoryStore;
@@ -84,92 +83,101 @@ where
         }
     }
 
+    /// Appends `leaves` to the tree and updates every ancestor they touch.
+    ///
+    /// Nodes are computed one level at a time rather than one leaf at a time.
+    /// The new leaves form a contiguous run at level 0, that run is paired up
+    /// into the run it produces at level 1, and so on to the root. Hashing a
+    /// level once instead of once per descendant leaf costs about `2 * leaves +
+    /// DEPTH` hashes per call instead of `leaves * DEPTH`, so the saving grows
+    /// with the batch size.
     pub fn add_leaves(&mut self, leaves: &[Node]) -> Result<(), MerkleError> {
         // Early return
         if leaves.is_empty() {
             return Ok(());
         }
 
+        let num_leaves = self.store.get_num_leaves();
+
         // Error if leaves do not fit in the tree
         // TODO: Avoid calculating this. Calculate it at init or do the shifting with the generic.
-        if self.store.get_num_leaves() + leaves.len() as u64 > (1 << DEPTH as u64) {
+        if num_leaves + leaves.len() as u64 > (1 << DEPTH as u64) {
             return Err(MerkleError::TreeFull {
                 depth: DEPTH as u32,
                 capacity: 1 << DEPTH as u64,
             });
         }
 
-        // Stores the levels and hashes to be written in a single batch.
-        // This allows to batch all writes in a single batch transaction.
-        let mut batch: Vec<(u32, u64, Node)> = Vec::with_capacity(leaves.len() * (DEPTH + 1));
-
-        // Cache for nodes generated in this batch so we can reuse them
-        let mut cache: HashMap<(u32, u64), Node> = HashMap::new();
-
-        for (offset, leaf) in leaves.iter().enumerate() {
-            let mut idx = self.store.get_num_leaves() + offset as u64;
-            let mut h = *leaf;
-
-            // Store the leaf
-            batch.push((0, idx, h));
-            cache.insert((0, idx), h);
-
-            // Collect siblings that are not already cached so we can fetch them in one batch.
-            let mut levels_to_fetch = [0u32; DEPTH];
-            let mut indices_to_fetch = [0u64; DEPTH];
-            let mut fetch_len = 0usize;
-
-            let mut tmp_idx = idx;
-            for lvl in 0..DEPTH {
-                let sibling_idx = tmp_idx ^ 1;
-                if !cache.contains_key(&(lvl as u32, sibling_idx)) {
-                    levels_to_fetch[fetch_len] = lvl as u32;
-                    indices_to_fetch[fetch_len] = sibling_idx;
-                    fetch_len += 1;
-                }
-                tmp_idx >>= 1;
-            }
-
-            // Batch-fetch the missing siblings and insert them in cache.
-            if fetch_len != 0 {
-                let fetched = self.store.get(
-                    &levels_to_fetch[..fetch_len],
-                    &indices_to_fetch[..fetch_len],
-                )?;
-
-                for (i, maybe_node) in fetched.into_iter().enumerate() {
-                    if let Some(node) = maybe_node {
-                        cache.insert((levels_to_fetch[i], indices_to_fetch[i]), node);
-                    }
-                }
-            }
-
-            for level in 0..DEPTH {
-                let sibling_idx = idx ^ 1;
-
-                let sib_hash = cache
-                    .get(&(level as u32, sibling_idx))
-                    .copied()
-                    .unwrap_or(self.zeros[level]);
-
-                let (left, right) = if idx & 1 == 1 {
-                    (sib_hash, h)
-                } else {
-                    (h, sib_hash)
-                };
-
-                h = self.hasher.hash(&left, &right);
-                idx >>= 1;
-
-                batch.push(((level + 1) as u32, idx, h));
-                cache.insert(((level + 1) as u32, idx), h);
+        // The run at level `l` starts at `num_leaves >> l`, so which left
+        // partners are missing is known before hashing and they all fit in a
+        // single read.
+        let mut fetch_levels = [0u32; DEPTH];
+        let mut fetch_indices = [0u64; DEPTH];
+        let mut fetch_len = 0usize;
+        for level in 0..DEPTH {
+            let start = num_leaves >> level;
+            if start & 1 == 1 {
+                fetch_levels[fetch_len] = level as u32;
+                fetch_indices[fetch_len] = start - 1;
+                fetch_len += 1;
             }
         }
 
-        // Update all values in a single batch
-        self.store.put(&batch)?;
+        // A partner left of a run start is always inside the stored prefix, so
+        // `None` cannot happen; treating it as zero keeps this consistent with
+        // how the tree reads every other absent node.
+        let mut left_partners = [Node::ZERO; DEPTH];
+        let fetched = self
+            .store
+            .get(&fetch_levels[..fetch_len], &fetch_indices[..fetch_len])?;
+        for (&level, node) in fetch_levels[..fetch_len].iter().zip(fetched) {
+            let level = level as usize;
+            left_partners[level] = node.unwrap_or(self.zeros[level]);
+        }
 
-        Ok(())
+        // Every node this call writes, tagged with its position, so the store
+        // sees one batch. Each node is emitted exactly once.
+        let mut batch: Vec<(u32, u64, Node)> = Vec::with_capacity(2 * leaves.len() + DEPTH);
+
+        let mut start = num_leaves;
+        let mut nodes = leaves.to_vec();
+        batch.extend(
+            nodes
+                .iter()
+                .enumerate()
+                .map(|(i, &node)| (0, start + i as u64, node)),
+        );
+
+        // Swapped with `nodes` each level, so both buffers are allocated once
+        // and reused: every level is at most half the size of the one below.
+        let mut parents: Vec<Node> = Vec::with_capacity(nodes.len() / 2 + 1);
+
+        for (level, left_partner) in left_partners.iter().enumerate() {
+            parents.clear();
+
+            let pairs = if start & 1 == 1 {
+                parents.push(self.hasher.hash(left_partner, &nodes[0]));
+                &nodes[1..]
+            } else {
+                &nodes[..]
+            };
+            for pair in pairs.chunks(2) {
+                let right = pair.get(1).unwrap_or(&self.zeros[level]);
+                parents.push(self.hasher.hash(&pair[0], right));
+            }
+
+            start >>= 1;
+            std::mem::swap(&mut nodes, &mut parents);
+            batch.extend(
+                nodes
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &node)| ((level + 1) as u32, start + i as u64, node)),
+            );
+        }
+
+        // Update all values in a single batch
+        self.store.put(&batch)
     }
 
     pub fn root(&self) -> Result<Node, MerkleError> {
@@ -370,6 +378,48 @@ mod tests {
             assert_eq!(zero, &expected_zeros[i]);
         }
         assert_eq!(tree.zeros.last, expected_zeros[32]);
+    }
+
+    #[cfg(feature = "memory_store")]
+    #[test]
+    fn test_batching_matches_incremental() {
+        const DEPTH: usize = 8;
+        type Tree = MerkleTree<Keccak256Hasher, MemoryStore, DEPTH>;
+        let new_tree = || Tree::new(Keccak256Hasher, MemoryStore::default());
+
+        let leaves: Vec<Node> = (0..100)
+            .map(|i| to_node!(format!("0x{:064x}", i).as_str()))
+            .collect();
+
+        // One leaf per call never has a run to pair up, so it is the reference
+        // the batched paths must reproduce.
+        let mut reference = new_tree();
+        for leaf in &leaves {
+            reference.add_leaves(&[*leaf]).unwrap();
+        }
+        let expected = reference.root().unwrap();
+
+        // Odd sizes leave the frontier on an odd index, forcing the next call
+        // to pair its run against stored left partners; sizes above a power of
+        // two make a run span more than one parent at the upper levels.
+        for size in [1, 2, 3, 5, 7, 8, 16, 33, 99, 100] {
+            let mut tree = new_tree();
+            for batch in leaves.chunks(size) {
+                tree.add_leaves(batch).unwrap();
+            }
+
+            assert_eq!(tree.num_leaves(), leaves.len() as u64, "batch size {size}");
+            assert_eq!(tree.root().unwrap(), expected, "batch size {size}");
+
+            for (i, leaf) in leaves.iter().enumerate() {
+                let proof = tree.proof(i as u64).unwrap();
+                assert_eq!(&proof.leaf, leaf, "batch size {size}, leaf {i}");
+                assert!(
+                    tree.verify_proof(&proof).unwrap(),
+                    "batch size {size}, leaf {i}"
+                );
+            }
+        }
     }
 
     #[cfg(feature = "memory_store")]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -88,7 +88,7 @@ where
     /// Nodes are computed one level at a time rather than one leaf at a time.
     /// The new leaves form a contiguous run at level 0, that run is paired up
     /// into the run it produces at level 1, and so on to the root. Hashing a
-    /// level once instead of once per descendant leaf costs about `2 * leaves +
+    /// level once instead of once per descendant leaf costs at most `leaves +
     /// DEPTH` hashes per call instead of `leaves * DEPTH`, so the saving grows
     /// with the batch size.
     pub fn add_leaves(&mut self, leaves: &[Node]) -> Result<(), MerkleError> {
@@ -148,12 +148,8 @@ where
                 .map(|(i, &node)| (0, start + i as u64, node)),
         );
 
-        // Swapped with `nodes` each level, so both buffers are allocated once
-        // and reused: every level is at most half the size of the one below.
-        let mut parents: Vec<Node> = Vec::with_capacity(nodes.len() / 2 + 1);
-
         for (level, left_partner) in left_partners.iter().enumerate() {
-            parents.clear();
+            let mut parents: Vec<Node> = Vec::with_capacity(nodes.len() / 2 + 1);
 
             let pairs = if start & 1 == 1 {
                 parents.push(self.hasher.hash(left_partner, &nodes[0]));
@@ -167,7 +163,7 @@ where
             }
 
             start >>= 1;
-            std::mem::swap(&mut nodes, &mut parents);
+            nodes = parents;
             batch.extend(
                 nodes
                     .iter()
@@ -378,6 +374,51 @@ mod tests {
             assert_eq!(zero, &expected_zeros[i]);
         }
         assert_eq!(tree.zeros.last, expected_zeros[32]);
+    }
+
+    /// Roots the fully padded tree bottom up, sharing no logic with the
+    /// incremental path: no runs, no frontier, no stored state.
+    #[cfg(feature = "memory_store")]
+    fn reference_root(hasher: &Keccak256Hasher, depth: usize, leaves: &[Node]) -> Node {
+        let mut level = vec![Node::ZERO; 1 << depth];
+        level[..leaves.len()].copy_from_slice(leaves);
+        for _ in 0..depth {
+            level = level
+                .chunks(2)
+                .map(|pair| hasher.hash(&pair[0], &pair[1]))
+                .collect();
+        }
+        level[0]
+    }
+
+    #[cfg(feature = "memory_store")]
+    #[test]
+    fn test_root_matches_full_recomputation() {
+        const DEPTH: usize = 8;
+
+        for num_leaves in [1usize, 2, 3, 8, 9, 100, 255, 256] {
+            // Leaves are non-zero so that a node left unwritten by mistake
+            // cannot pass as the padding it sits next to.
+            let leaves: Vec<Node> = (1..=num_leaves)
+                .map(|i| to_node!(format!("0x{:064x}", i).as_str()))
+                .collect();
+            let expected = reference_root(&Keccak256Hasher, DEPTH, &leaves);
+
+            for size in [1, 3, 16, 256] {
+                let mut tree = MerkleTree::<Keccak256Hasher, MemoryStore, DEPTH>::new(
+                    Keccak256Hasher,
+                    MemoryStore::default(),
+                );
+                for batch in leaves.chunks(size) {
+                    tree.add_leaves(batch).unwrap();
+                }
+                assert_eq!(
+                    tree.root().unwrap(),
+                    expected,
+                    "{num_leaves} leaves in batches of {size}"
+                );
+            }
+        }
     }
 
     #[cfg(feature = "memory_store")]

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -76,6 +76,55 @@ fn test_merkle_tree_keccak_32_memory() {
     // TODO: Once async is implemented, ensure proofs are always consistent.
 }
 
+#[cfg(all(feature = "file_store", feature = "memory_store"))]
+#[test]
+fn test_merkle_tree_keccak_32_file() {
+    let dir = std::env::temp_dir().join(format!("rs-merkle-tree-golden-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    let path = dir.to_str().expect("utf-8 temp path").to_owned();
+
+    let leaves = (0..10_001)
+        .map(|i| to_node!(format!("0x{:064x}", i).as_str()))
+        .collect::<Vec<Node>>();
+
+    // The same golden root as the memory store, reached through the on-disk
+    // layout. FileStore rejects any batch that is not one contiguous run per
+    // level, so this also pins the shape `add_leaves` emits at all 33 levels.
+    let mut tree: MerkleTree<Keccak256Hasher, FileStore, 32> =
+        MerkleTree::new(Keccak256Hasher, FileStore::new(&path));
+    for batch in leaves[..10_000].chunks(1_000) {
+        tree.add_leaves(batch).unwrap();
+    }
+
+    assert_eq!(tree.num_leaves(), 10_000);
+    assert_eq!(
+        tree.root().unwrap(),
+        to_node!("0x532c79f3ea0f4873946d1b14770eaa1c157255a003e73da987b858cc287b0482")
+    );
+
+    // Appending after a reopen is the only path that reads left partners back
+    // from disk rather than from nodes this process just wrote.
+    drop(tree);
+    let mut tree: MerkleTree<Keccak256Hasher, FileStore, 32> =
+        MerkleTree::new(Keccak256Hasher, FileStore::new(&path));
+    assert_eq!(tree.num_leaves(), 10_000);
+    tree.add_leaves(&leaves[10_000..]).unwrap();
+
+    let mut expected: MerkleTree32 = MerkleTree::new(Keccak256Hasher, MemoryStore::default());
+    expected.add_leaves(&leaves).unwrap();
+
+    assert_eq!(tree.num_leaves(), 10_001);
+    assert_eq!(tree.root().unwrap(), expected.root().unwrap());
+
+    for i in [0, 1, 4_999, 9_999, 10_000] {
+        let proof = tree.proof(i).unwrap();
+        assert_eq!(proof.leaf, leaves[i as usize]);
+        assert!(tree.verify_proof(&proof).unwrap());
+    }
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
 #[cfg(any(
     feature = "sled_store",
     feature = "sqlite_store",


### PR DESCRIPTION
The current `add_leaves` function that batches adding new leaves was suboptimal. It was hashing tons of redundant nodes. This PR fixes that. Reducing by 30x the amount of hashes that are calculated with a batch size of 1000 and depth of 32.

## Example

Lets say you want to batch add 8 leaves to an empty tree via `add_leaves`. The leaves are stored at the bottom and all intermediate levels are hashed and stored.

```
           R                    level 3 (root)
        /     \
     C0         C1              level 2
    /  \       /  \
  B0    B1   B2    B3           level 1
 / \   / \   / \   / \
0  1  2  3  4  5  6  7          level 0 (leaves)
```

With the previous implementation, each leaf hashed its own way up to the root. Z0, Z1 and Z2 below are the precomputed roots of empty subtrees, one per height.
* Adding leaf 0 updates every node on its path. B0=h(0, Z0), C0=h(B0, Z1), R=h(C0, Z2). 3 hashes.
* Adding leaf 1 recomputes that same path, now with a real sibling. B0=h(0, 1), C0=h(B0, Z1), R=h(C0, Z2). 3 hashes, and the three from the previous step are thrown away.
* Leaf 2 does the same along its own path, B1, C0 and R, and so on for leaves 3 to 7.
* So in total: 8*3 = 24 hashes to produce 7 nodes. R alone is computed 8 times and C0 4 times, with only the last result of each surviving.

The fix computes each level once instead of each path once.
* First pair up the new leaves. B0=h(0, 1), B1=h(2, 3), B2=h(4, 5), B3=h(6, 7). Just 4.
* Then the same for the level above. C0=h(B0, B1), C1=h(B2, B3). Just 2.
* And the root. R=h(C0, C1). Just 1.
* Total: 7 hashes, one per node written.

Note that 24 vs 7 hashes is for this particular example, but this delta is even greater with larger batch sizes and deeper trees.