### PR TITLE
Use rayon multithread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ thiserror = "2.0.16"
 ark-bn254 = "0.5.0"
 ark-ff = "0.5.0"
 light-poseidon = "0.4"
+rayon = "1.11"
 
 # Conditional dependencies based on features
 sled = { version = "0.34.7", optional = true }

--- a/README.md
+++ b/README.md
@@ -149,21 +149,21 @@ python benchmarks.py
 
 | Depth | Hash | Leaves | Batch | Store | Throughput | p50 batch | p99 batch | Disk |
 |---|---|---|---|---|---|---|---|---|
-| 32 | keccak256 | 1000000 | 1000 | memory | 4.827 Melem/s | 189.084 µs | 473.167 µs | - |
-| 32 | keccak256 | 1000000 | 1000 | file | 4.214 Melem/s | 232.750 µs | 349.000 µs | 61.04 MiB |
-| 32 | keccak256 | 1000000 | 1000 | rocksdb | 2.622 Melem/s | 380.500 µs | 472.541 µs | 88.70 MiB |
-| 32 | keccak256 | 1000000 | 1000 | sqlite | 731.882 Kelem/s | 1.181 ms | 4.470 ms | 116.88 MiB |
-| 32 | keccak256 | 1000000 | 1000 | sled | 348.847 Kelem/s | 2.799 ms | 4.665 ms | 646.00 MiB |
+| 32 | keccak256 | 5000000 | 100000 | memory | 23.667 Melem/s | 3.961 ms | 8.534 ms | - |
+| 32 | keccak256 | 5000000 | 100000 | file | 19.883 Melem/s | 4.551 ms | 15.335 ms | 305.18 MiB |
+| 32 | keccak256 | 5000000 | 100000 | rocksdb | 4.489 Melem/s | 22.324 ms | 24.710 ms | 434.26 MiB |
+| 32 | keccak256 | 5000000 | 100000 | sqlite | 886.759 Kelem/s | 112.151 ms | 135.632 ms | 590.39 MiB |
+| 32 | keccak256 | 5000000 | 100000 | sled | 218.799 Kelem/s | 463.476 ms | 541.145 ms | 1.00 GiB |
 
 ### `proof` time
 
 | Depth | Hash | Store | Time |
 |---|---|---|---|
-| 32 | keccak256 | memory | 187.910 ns |
-| 32 | keccak256 | file | 4.779 µs |
-| 32 | keccak256 | sled | 6.268 µs |
-| 32 | keccak256 | sqlite | 11.226 µs |
-| 32 | keccak256 | rocksdb | 12.585 µs |
+| 32 | keccak256 | memory | 191.740 ns |
+| 32 | keccak256 | file | 4.869 µs |
+| 32 | keccak256 | sled | 6.571 µs |
+| 32 | keccak256 | sqlite | 11.411 µs |
+| 32 | keccak256 | rocksdb | 12.693 µs |
 
 ## License
 

--- a/benches/insertions.rs
+++ b/benches/insertions.rs
@@ -31,7 +31,7 @@ const ROOT: &str = "bench_stores";
 
 /// Leaves inserted into every store. Fixed rather than configurable so that two
 /// runs, on any machine, always describe the same workload.
-const LEAVES: u64 = 1_000_000;
+const LEAVES: u64 = 5_000_000;
 
 const DEFAULT_BATCH: u64 = 1_000;
 

--- a/benches/insertions.rs
+++ b/benches/insertions.rs
@@ -33,7 +33,7 @@ const ROOT: &str = "bench_stores";
 /// runs, on any machine, always describe the same workload.
 const LEAVES: u64 = 5_000_000;
 
-const DEFAULT_BATCH: u64 = 1_000;
+const DEFAULT_BATCH: u64 = 100_000;
 
 /// Equal slices the run is cut into for the per-slice throughput reported in
 /// JSON. A decreasing series is how a store that degrades as it fills shows up.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,6 +5,7 @@
 use crate::hasher::{Hasher, Keccak256Hasher};
 use crate::{MerkleError, Node, Store};
 use core::ops::Index;
+use rayon::prelude::*;
 
 #[cfg(feature = "memory_store")]
 use crate::stores::MemoryStore;
@@ -42,6 +43,10 @@ pub struct Zeros<const DEPTH: usize> {
     front: [Node; DEPTH],
     last: Node,
 }
+
+/// Below this many hashes, Rayon scheduling costs more than serial hashing for
+/// inexpensive hashers such as Keccak-256.
+const MIN_PARALLEL_HASHES: usize = 64;
 
 // TODO: Maybe use "typenum" crate to avoid this.
 impl<const DEPTH: usize> Index<usize> for Zeros<DEPTH> {
@@ -90,8 +95,12 @@ where
     /// into the run it produces at level 1, and so on to the root. Hashing a
     /// level once instead of once per descendant leaf costs at most `leaves +
     /// DEPTH` hashes per call instead of `leaves * DEPTH`, so the saving grows
-    /// with the batch size.
-    pub fn add_leaves(&mut self, leaves: &[Node]) -> Result<(), MerkleError> {
+    /// with the batch size. Independent pairs on sufficiently large levels are
+    /// hashed in parallel on Rayon's global thread pool.
+    pub fn add_leaves(&mut self, leaves: &[Node]) -> Result<(), MerkleError>
+    where
+        H: Sync,
+    {
         // Early return
         if leaves.is_empty() {
             return Ok(());
@@ -157,9 +166,15 @@ where
             } else {
                 &nodes[..]
             };
-            for pair in pairs.chunks(2) {
+
+            let hash_pair = |pair: &[Node]| {
                 let right = pair.get(1).unwrap_or(&self.zeros[level]);
-                parents.push(self.hasher.hash(&pair[0], right));
+                self.hasher.hash(&pair[0], right)
+            };
+            if pairs.len().div_ceil(2) >= MIN_PARALLEL_HASHES {
+                parents.par_extend(pairs.par_chunks(2).map(hash_pair));
+            } else {
+                parents.extend(pairs.chunks(2).map(hash_pair));
             }
 
             start >>= 1;
@@ -418,6 +433,30 @@ mod tests {
                     "{num_leaves} leaves in batches of {size}"
                 );
             }
+        }
+    }
+
+    #[cfg(feature = "memory_store")]
+    #[test]
+    fn test_parallel_batch_after_odd_prefix() {
+        const DEPTH: usize = 8;
+        let leaves: Vec<Node> = (1..=1 << DEPTH)
+            .map(|i| to_node!(format!("0x{:064x}", i).as_str()))
+            .collect();
+        let expected = reference_root(&Keccak256Hasher, DEPTH, &leaves);
+        let mut tree = MerkleTree::<Keccak256Hasher, MemoryStore, DEPTH>::new(
+            Keccak256Hasher,
+            MemoryStore::default(),
+        );
+
+        tree.add_leaves(&leaves[..1]).unwrap();
+        tree.add_leaves(&leaves[1..]).unwrap();
+
+        assert_eq!(tree.root().unwrap(), expected);
+        for index in [0, 1, 127, 128, 255] {
+            let proof = tree.proof(index).unwrap();
+            assert_eq!(proof.leaf, leaves[index as usize]);
+            assert!(tree.verify_proof(&proof).unwrap());
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -171,7 +171,7 @@ where
                 let right = pair.get(1).unwrap_or(&self.zeros[level]);
                 self.hasher.hash(&pair[0], right)
             };
-            if pairs.len().div_ceil(2) >= MIN_PARALLEL_HASHES {
+            if pairs.len() >= 2 * MIN_PARALLEL_HASHES {
                 parents.par_extend(pairs.par_chunks(2).map(hash_pair));
             } else {
                 parents.extend(pairs.chunks(2).map(hash_pair));


### PR DESCRIPTION
* This PR uses rayon to leverage multilpe cores to hash the leaves, massively increasing insertion throughput from 5M per second to around 20M per second.
* It leverages multithreading to hash the elements of each level in paralel, with a minimum amount of leaves. Below that number, hashing is done in serial, since the overhead of rayon wont make it faster.
* See the comments for future improvements that will follow up.