### PR TITLE
Integrate SIMD hashing crate with AVX and others

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ rand = "0.9.2"
 futures = "0.3"
 syn = { version = "1.0.107", features = ["full"] }
 quote = "1.0.23"
-tiny-keccak = { version = "2.0", features = ["keccak"] }
+keccak-batch = "0.1"
 byteorder = "1.4"
 thiserror = "2.0.16"
 ark-bn254 = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -147,21 +147,21 @@ python benchmarks.py
 
 | Depth | Hash | Leaves | Batch | Store | Throughput | p50 batch | p99 batch | Disk |
 |---|---|---|---|---|---|---|---|---|
-| 32 | keccak256 | 5000000 | 100000 | file | 25.181 Melem/s | 3.655 ms | 8.674 ms | 305.18 MiB |
-| 32 | keccak256 | 5000000 | 100000 | memory | 23.146 Melem/s | 3.995 ms | 7.106 ms | - |
-| 32 | keccak256 | 5000000 | 100000 | rocksdb | 4.329 Melem/s | 22.887 ms | 27.705 ms | 434.44 MiB |
-| 32 | keccak256 | 5000000 | 100000 | sqlite | 910.493 Kelem/s | 109.710 ms | 129.759 ms | 590.39 MiB |
-| 32 | keccak256 | 5000000 | 100000 | sled | 248.482 Kelem/s | 397.198 ms | 513.669 ms | 1.57 GiB |
+| 32 | keccak256 | 5000000 | 100000 | memory | 39.313 Melem/s | 2.427 ms | 4.635 ms | - |
+| 32 | keccak256 | 5000000 | 100000 | file | 37.368 Melem/s | 2.395 ms | 12.944 ms | 305.18 MiB |
+| 32 | keccak256 | 5000000 | 100000 | rocksdb | 4.417 Melem/s | 21.372 ms | 36.797 ms | 434.44 MiB |
+| 32 | keccak256 | 5000000 | 100000 | sqlite | 865.615 Kelem/s | 114.323 ms | 162.012 ms | 590.39 MiB |
+| 32 | keccak256 | 5000000 | 100000 | sled | 247.057 Kelem/s | 399.358 ms | 594.720 ms | 1.61 GiB |
 
 ### `proof` time
 
 | Depth | Hash | Store | Time |
 |---|---|---|---|
-| 32 | keccak256 | memory | 193.740 ns |
-| 32 | keccak256 | file | 4.888 µs |
-| 32 | keccak256 | sled | 6.679 µs |
-| 32 | keccak256 | sqlite | 11.727 µs |
-| 32 | keccak256 | rocksdb | 14.041 µs |
+| 32 | keccak256 | memory | 195.890 ns |
+| 32 | keccak256 | file | 4.899 µs |
+| 32 | keccak256 | sled | 6.528 µs |
+| 32 | keccak256 | sqlite | 11.621 µs |
+| 32 | keccak256 | rocksdb | 14.129 µs |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/bilinearlabs/rs-merkle-tree/rust_main_ci.yml?style=flat-square)
 ![Codecov (with branch)](https://img.shields.io/codecov/c/github/bilinearlabs/rs-merkle-tree/main?token=1PIHE7U7XQ&style=flat-square)
 ![GitHub License](https://img.shields.io/github/license/bilinearlabs/rs-merkle-tree?style=flat-square)
-[![Join our Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=flat-square)](https://discord.gg/Et8BTnVBZS)
 
 Merkle tree implementation in Rust with the following features:
 * Fixed depth: All proofs have a constant size equal to the `Depth`.
@@ -110,6 +109,14 @@ fn main() {
     let mut tree: MerkleTree<Keccak256Hasher, FileStore, 32> =
         MerkleTree::new(Keccak256Hasher, FileStore::new("filestore.db"));
 }
+```
+
+## Tests
+
+
+Run all tests
+```
+cargo test --all-features
 ```
 
 ## Stores

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -2,24 +2,61 @@ use crate::node::Node;
 
 use ark_bn254::Fr;
 
+use keccak_batch::{keccak256, keccak256_many};
 use light_poseidon::{Poseidon, PoseidonBytesHasher};
-use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 
 pub trait Hasher {
     fn hash(&self, left: &Node, right: &Node) -> Node;
+
+    /// Hashes `pairs[i]` into `out[i]`; `pairs` and `out` must be equally long.
+    fn hash_pairs(&self, pairs: &[[Node; 2]], out: &mut [Node]) {
+        debug_assert_eq!(pairs.len(), out.len());
+        for (parent, [left, right]) in out.iter_mut().zip(pairs) {
+            *parent = self.hash(left, right);
+        }
+    }
 }
 
-// Implements the keccak256 hash function.
+/// One `left || right` message, the only shape this tree ever hashes.
+const MESSAGE: usize = 2 * Node::LEN;
+
+/// Pairs `keccak256_many` hashes per permutation: the four 64-bit SIMD lanes
+/// of a 256-bit register, each carrying one independent message.
+// TODO: This depends on the hardware. Compilation flag?
+const LANES: usize = 4;
+
 pub struct Keccak256Hasher;
+
 impl Hasher for Keccak256Hasher {
     fn hash(&self, left: &Node, right: &Node) -> Node {
-        // TODO: Don't instantiate a new keccak for each hash.
-        let mut keccak = Keccak::v256();
-        keccak.update(left.as_ref());
-        keccak.update(right.as_ref());
-        let mut buf = [0u8; 32];
-        keccak.finalize(&mut buf);
-        Node::from(buf)
+        let mut message = [0u8; MESSAGE];
+        message[..Node::LEN].copy_from_slice(left.as_ref());
+        message[Node::LEN..].copy_from_slice(right.as_ref());
+        Node::from(keccak256(message))
+    }
+
+    fn hash_pairs(&self, pairs: &[[Node; 2]], out: &mut [Node]) {
+        debug_assert_eq!(pairs.len(), out.len());
+
+        // A run of pairs is contiguous bytes, so every pair already sits in
+        // memory as the 64-byte message it hashes to; the batch borrows
+        // straight from the level instead of staging copies.
+        let messages = Node::as_bytes(pairs.as_flattened()).chunks_exact(LANES * MESSAGE);
+        let mut parents = out.chunks_exact_mut(LANES);
+
+        for (batch, parents) in messages.zip(parents.by_ref()) {
+            let inputs: [&[u8]; LANES] =
+                core::array::from_fn(|i| &batch[i * MESSAGE..(i + 1) * MESSAGE]);
+            for (parent, digest) in parents.iter_mut().zip(keccak256_many(&inputs)) {
+                *parent = Node::from(digest);
+            }
+        }
+
+        let rest = parents.into_remainder();
+        let rest_pairs = &pairs[pairs.len() - rest.len()..];
+        for (parent, [left, right]) in rest.iter_mut().zip(rest_pairs) {
+            *parent = self.hash(left, right);
+        }
     }
 }
 
@@ -55,6 +92,24 @@ mod tests {
             result,
             to_node!("0x760bde345debf3075c7fc0bcd2134e16ce5fc1a13adaa66ec6452a391f70595c")
         );
+    }
+
+    /// Every batch size around the SIMD lane count, so full batches, the
+    /// scalar remainder, and the empty run all reproduce pair-by-pair hashing.
+    #[test]
+    fn test_keccak256_hash_pairs_matches_hash() {
+        let hasher = Keccak256Hasher;
+        let pairs: Vec<[Node; 2]> = (0..13).map(|_| [Node::random(), Node::random()]).collect();
+
+        for len in [0, 1, 3, 4, 5, 8, 13] {
+            let pairs = &pairs[..len];
+            let mut parents = vec![Node::ZERO; len];
+            hasher.hash_pairs(pairs, &mut parents);
+
+            for (i, (parent, [left, right])) in parents.iter().zip(pairs).enumerate() {
+                assert_eq!(parent, &hasher.hash(left, right), "pair {i} of {len}");
+            }
+        }
     }
 
     #[test]

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -2,7 +2,7 @@ use crate::node::Node;
 
 use ark_bn254::Fr;
 
-use keccak_batch::{keccak256, keccak256_many};
+use keccak_batch::{keccak256, keccak256_many_into};
 use light_poseidon::{Poseidon, PoseidonBytesHasher};
 
 pub trait Hasher {
@@ -10,7 +10,7 @@ pub trait Hasher {
 
     /// Hashes `pairs[i]` into `out[i]`; `pairs` and `out` must be equally long.
     fn hash_pairs(&self, pairs: &[[Node; 2]], out: &mut [Node]) {
-        debug_assert_eq!(pairs.len(), out.len());
+        assert_eq!(pairs.len(), out.len(), "pairs and out must be equally long");
         for (parent, [left, right]) in out.iter_mut().zip(pairs) {
             *parent = self.hash(left, right);
         }
@@ -20,10 +20,16 @@ pub trait Hasher {
 /// One `left || right` message, the only shape this tree ever hashes.
 const MESSAGE: usize = 2 * Node::LEN;
 
-/// Pairs `keccak256_many` hashes per permutation: the four 64-bit SIMD lanes
-/// of a 256-bit register, each carrying one independent message.
-// TODO: This depends on the hardware. Compilation flag?
-const LANES: usize = 4;
+/// This is the biggest batch we pass to `keccak256_many_into`, but
+/// note that the function detects the widest backend the
+/// running CPU supports and splits each batch across it.
+/// This is set to 8 since is the widest batch any backend consumes, AVX-512
+/// running eight 64-bit lanes.
+/// This allows to not allocate memory in the heap, since size is known at compile
+/// time. But note that this number acts as an upper limit. A platform supporting only
+/// 4 operations in paralel, will pass `keccak256_many_into` with 8 hashes, but unthe the hood
+/// it will be split in 2 batches.
+const STAGE: usize = 8;
 
 pub struct Keccak256Hasher;
 
@@ -36,26 +42,26 @@ impl Hasher for Keccak256Hasher {
     }
 
     fn hash_pairs(&self, pairs: &[[Node; 2]], out: &mut [Node]) {
-        debug_assert_eq!(pairs.len(), out.len());
+        assert_eq!(pairs.len(), out.len(), "pairs and out must be equally long");
 
-        // A run of pairs is contiguous bytes, so every pair already sits in
-        // memory as the 64-byte message it hashes to; the batch borrows
-        // straight from the level instead of staging copies.
-        let messages = Node::as_bytes(pairs.as_flattened()).chunks_exact(LANES * MESSAGE);
-        let mut parents = out.chunks_exact_mut(LANES);
+        // For each STAGE batch
+        for (group, parents) in pairs.chunks(STAGE).zip(out.chunks_mut(STAGE)) {
+            // We need to convert to &[&[u8]], which is what keccak256_many_into
+            // accepts.
+            let mut staged: [&[u8]; STAGE] = [&[]; STAGE];
+            for (slot, pair) in staged.iter_mut().zip(group) {
+                *slot = Node::as_bytes(pair);
+            }
 
-        for (batch, parents) in messages.zip(parents.by_ref()) {
-            let inputs: [&[u8]; LANES] =
-                core::array::from_fn(|i| &batch[i * MESSAGE..(i + 1) * MESSAGE]);
-            for (parent, digest) in parents.iter_mut().zip(keccak256_many(&inputs)) {
+            // Trimming to the run length lets the last batch be short: a
+            // partial batch is split across the narrower widths, not dropped
+            // to a scalar tail.
+            let mut digests = [[0u8; Node::LEN]; STAGE];
+            keccak256_many_into(&staged[..group.len()], &mut digests[..group.len()]);
+
+            for (parent, digest) in parents.iter_mut().zip(digests) {
                 *parent = Node::from(digest);
             }
-        }
-
-        let rest = parents.into_remainder();
-        let rest_pairs = &pairs[pairs.len() - rest.len()..];
-        for (parent, [left, right]) in rest.iter_mut().zip(rest_pairs) {
-            *parent = self.hash(left, right);
         }
     }
 }
@@ -94,14 +100,15 @@ mod tests {
         );
     }
 
-    /// Every batch size around the SIMD lane count, so full batches, the
-    /// scalar remainder, and the empty run all reproduce pair-by-pair hashing.
+    /// Batch sizes either side of every SIMD width the crate dispatches to and
+    /// of the staging buffer, so full batches, short trailing batches, and the
+    /// empty run all reproduce pair-by-pair hashing.
     #[test]
     fn test_keccak256_hash_pairs_matches_hash() {
         let hasher = Keccak256Hasher;
-        let pairs: Vec<[Node; 2]> = (0..13).map(|_| [Node::random(), Node::random()]).collect();
+        let pairs: Vec<[Node; 2]> = (0..65).map(|_| [Node::random(), Node::random()]).collect();
 
-        for len in [0, 1, 3, 4, 5, 8, 13] {
+        for len in [0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 65] {
             let pairs = &pairs[..len];
             let mut parents = vec![Node::ZERO; len];
             hasher.hash_pairs(pairs, &mut parents);
@@ -110,6 +117,12 @@ mod tests {
                 assert_eq!(parent, &hasher.hash(left, right), "pair {i} of {len}");
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "pairs and out must be equally long")]
+    fn test_keccak256_hash_pairs_rejects_length_mismatch() {
+        Keccak256Hasher.hash_pairs(&[[Node::ZERO, Node::ZERO]], &mut []);
     }
 
     #[test]

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -9,6 +9,9 @@ pub trait Hasher {
     fn hash(&self, left: &Node, right: &Node) -> Node;
 
     /// Hashes `pairs[i]` into `out[i]`; `pairs` and `out` must be equally long.
+    /// This is a default implementation. If your hashing implementation doesnt support
+    /// vectorization, there is no need to implement this. If it does (see keccak)
+    /// you can optionally implement this, which hashes pairs faster than the naive implementation.
     fn hash_pairs(&self, pairs: &[[Node; 2]], out: &mut [Node]) {
         assert_eq!(pairs.len(), out.len(), "pairs and out must be equally long");
         for (parent, [left, right]) in out.iter_mut().zip(pairs) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -44,8 +44,8 @@ pub struct Zeros<const DEPTH: usize> {
     last: Node,
 }
 
-/// Below this many hashes, Rayon scheduling costs more than serial hashing for
-/// inexpensive hashers such as Keccak-256.
+/// Below this many hashes, Rayon scheduling costs more than serial hashing.
+// TODO: This depends on the type of hashing algorithm and perhaps the hardware.
 const MIN_PARALLEL_HASHES: usize = 64;
 
 // TODO: Maybe use "typenum" crate to avoid this.
@@ -152,23 +152,30 @@ where
         self.store.put(0, start, &nodes)?;
 
         for (level, left_partner) in left_partners.iter().enumerate() {
-            let mut parents: Vec<Node> = Vec::with_capacity(nodes.len() / 2 + 1);
+            // The run pairs up as: an odd start pairs the stored left partner
+            // with the first node, an odd end pairs the last node with this
+            // level's zero, and everything between pairs consecutive nodes.
+            // Splitting the edges off up front leaves whole pairs, so they go
+            // to the hasher as runs rather than one by one.
+            let head = usize::from(start & 1 == 1);
+            let (pairs, tail) = nodes[head..].as_chunks::<2>();
 
-            let pairs = if start & 1 == 1 {
-                parents.push(self.hasher.hash(left_partner, &nodes[0]));
-                &nodes[1..]
-            } else {
-                &nodes[..]
-            };
+            let mut parents = vec![Node::ZERO; head + pairs.len() + tail.len()];
+            if head == 1 {
+                parents[0] = self.hasher.hash(left_partner, &nodes[0]);
+            }
+            if let [last] = tail {
+                parents[head + pairs.len()] = self.hasher.hash(last, &self.zeros[level]);
+            }
 
-            let hash_pair = |pair: &[Node]| {
-                let right = pair.get(1).unwrap_or(&self.zeros[level]);
-                self.hasher.hash(&pair[0], right)
-            };
-            if pairs.len() >= 2 * MIN_PARALLEL_HASHES {
-                parents.par_extend(pairs.par_chunks(2).map(hash_pair));
+            let body_out = &mut parents[head..head + pairs.len()];
+            if pairs.len() >= MIN_PARALLEL_HASHES {
+                pairs
+                    .par_chunks(MIN_PARALLEL_HASHES)
+                    .zip(body_out.par_chunks_mut(MIN_PARALLEL_HASHES))
+                    .for_each(|(pairs, out)| self.hasher.hash_pairs(pairs, out));
             } else {
-                parents.extend(pairs.chunks(2).map(hash_pair));
+                self.hasher.hash_pairs(pairs, body_out);
             }
 
             start >>= 1;


### PR DESCRIPTION
* Migrates from `tiny-keccak` to `keccak-batch` which leverages AVX and other similar extensions, allowing to batch some keccak instructions up to 8x.
* In a modest hardware with AVX2 (256 bits register so 256/64 = 4 batches) insertion throughput increases 2x.